### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -63,7 +63,7 @@ jobs:
           make build
 
       - name: Build, tag, and push Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: ${{ secrets.DOCKER_REGISTRY }}
           name: backpackrid/akunify


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore